### PR TITLE
changed black requirement to 22.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 requires = ["jupyterlab>=3.0.0"]
 
 dev_requires = requires + [
-    "black>=20.0*",
+    "black>=22.1.0",
     "bump2version>=1.0.0",
     "check-manifest",
     "flake8>=3.7.8",


### PR DESCRIPTION
The version requirement was incompatible with [PEP440](https://peps.python.org/pep-0440/). 
I also bumped it to black 22.1.0, which is the first release of black that was not marked as pre-release on PyPI: https://pypi.org/project/black/#history