### PR TITLE
Use nb server logging instead of print

### DIFF
--- a/jupyterlab_templates/extension.py
+++ b/jupyterlab_templates/extension.py
@@ -115,7 +115,7 @@ def load_jupyter_server_extension(nb_server_app):
     base_url = web_app.settings["base_url"]
 
     host_pattern = ".*$"
-    print(
+    nb_server_app.log.info(
         "Installing jupyterlab_templates handler on path %s"
         % url_path_join(base_url, "templates")
     )
@@ -129,10 +129,10 @@ def load_jupyter_server_extension(nb_server_app):
                 for x in jupyter_core.paths.jupyter_path()
             ]
         )
-    print("Search paths:\n\t%s" % "\n\t".join(template_dirs))
+    nb_server_app.log.info("Search paths:\n\t%s" % "\n\t".join(template_dirs))
 
     loader = TemplatesLoader(template_dirs)
-    print(
+    nb_server_app.log.info(
         "Available templates:\n\t%s"
         % "\n\t".join(t for t in loader.get_templates()[1].keys())
     )


### PR DESCRIPTION
The logs are printed just before `jupyter lab` finishes or not printed at all.

After the changes in this PR, the logs are printed during the load:
```
[I 2023-02-22 16:42:13.872 ServerApp] Installing jupyterlab_templates handler on path /templates
[I 2023-02-22 16:42:13.872 ServerApp] Search paths:
    	/Users/tos/.pyenv/versions/3.11.1/envs/tmp-jlab/lib/python3.11/site-packages/jupyterlab_templates/templates
    	/Users/tos/.pyenv/versions/3.11.1/envs/tmp-jlab/share/jupyter/notebook_templates
    	/Users/tos/Library/Jupyter/notebook_templates
    	/usr/local/share/jupyter/notebook_templates
    	/usr/share/jupyter/notebook_templates
[I 2023-02-22 16:42:13.874 ServerApp] Available templates:
    	/jupyterlab_templates/Sample.ipynb
[I 2023-02-22 16:42:13.875 ServerApp] jupyterlab_templates | extension was successfully loaded.
```