### PR TITLE
add allowed_extensions setting, allowing additional file extensions in templates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,13 @@ jobs:
       run: |
         make build
 
+    - name: Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheel-${{ matrix.os }}-${{ github.sha }}
+        path: dist/*.whl
+      if: ${{ always() }}
+
     - name: Lint
       run: |
         make lint

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jupyter server extension enable --py jupyterlab_templates
 install the server extension, and add the following to `jupyter_notebook_config.py`
 
 ```python3
+c.JupyterLabTemplates.allowed_extensions = ["*.ipynb"]
 c.JupyterLabTemplates.template_dirs = ['list', 'of', 'template', 'directories']
 c.JupyterLabTemplates.include_default = True
 c.JupyterLabTemplates.include_core_paths = True
@@ -52,7 +53,8 @@ If `include_default = True` the `notebook_templates` directory under the [jupyte
 
 
 ### Flags
-- `template_dirs`: a list of absolute directory paths. All `.ipynb` files in any *subdirectories* of these paths will be listed as templates
+- `allowed_extensions`: a list of extensions to allow templates for. (optional, default `["*.ipynb"]`)
+- `template_dirs`: a list of absolute directory paths. All files matching `allowed_extensions` in any *subdirectories* of these paths will be listed as templates
 - `include_default`: include the default Sample template (default True)
 - `include_core_paths`: include jupyter core paths (see: jupyter --paths) (default True)
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -103,22 +103,29 @@ function activate(app, menu, browser, launcher) {
                   const {path} = browser.defaultBrowser.model;
 
                   return new Promise((resolve) => {
+                    const ext = data.filename.split(".").pop().toLowerCase();
+                    const isNotebook = ext === "ipynb";
                     app.commands
                       .execute("docmanager:new-untitled", {
+                        ext,
                         path,
-                        type: "notebook",
+                        type: isNotebook ? "notebook" : "file",
                       })
                       .then((model) => {
                         app.commands
                           .execute("docmanager:open", {
-                            factory: "Notebook",
+                            factory: isNotebook ? "Notebook" : null,
                             path: model.path,
                           })
                           .then((widget) => {
                             // eslint-disable-next-line no-param-reassign
                             widget.isUntitled = true;
                             widget.context.ready.then(() => {
-                              widget.model.fromString(data.content);
+                              if (isNotebook) {
+                                widget.model.fromString(data.content);
+                              } else {
+                                widget.content.editor._editor.setValue(data.content);
+                              }
                               resolve(widget);
                             });
                           });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "jupyterlab>=3.5"
+    "jupyterlab>=3.5",
+    "notebook>=6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds an optional setting for allowing additional file extensions to be usable as templates!

potentially fixes #123 

I also added a dependency on `notebook` in the `pyproject.toml` as it was erroring in the actions tests without it!