### PR TITLE
Add template_label setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ c.JupyterLabTemplates.allowed_extensions = ["*.ipynb"]
 c.JupyterLabTemplates.template_dirs = ['list', 'of', 'template', 'directories']
 c.JupyterLabTemplates.include_default = True
 c.JupyterLabTemplates.include_core_paths = True
+c.JupyterLabTemplates.template_label = "Template"
 ```
 
 ## Templates for libraries
@@ -59,6 +60,7 @@ All notebooks in this directory will be ignored (but has no effect on subdirecto
 - `template_dirs`: a list of absolute directory paths. All files matching `allowed_extensions` in any *subdirectories* of these paths will be listed as templates
 - `include_default`: include the default Sample template (default True)
 - `include_core_paths`: include jupyter core paths (see: jupyter --paths) (default True)
+- `template_label`: set label for template UI icon (default "Template")
 
 
 ## Development

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -77,7 +77,9 @@ function activate(app, menu, browser, launcher) {
   // grab templates from serverextension
   request("get", `${PageConfig.getBaseUrl()}templates/names`).then((res) => {
     if (res.ok) {
-      templates = res.json();
+      const template_data = res.json();
+      templates = template_data.templates;
+      const templateLabel = template_data.template_label || "Template";
 
       if (Object.keys(templates).length > 0) {
         // Add an application command
@@ -90,7 +92,7 @@ function activate(app, menu, browser, launcher) {
               body: new OpenTemplateWidget(),
               buttons: [Dialog.cancelButton(), Dialog.okButton({label: "GO"})],
               focusNodeSelector: "input",
-              title: "Template",
+              title: templateLabel,
             }).then((result) => {
               if (result.button.label === "Cancel") {
                 return;
@@ -137,7 +139,7 @@ function activate(app, menu, browser, launcher) {
           },
           iconClass: "jp-TemplateIcon",
           isEnabled: () => true,
-          label: "Template",
+          label: templateLabel,
         });
 
         // Add a launcher item if the launcher is available.

--- a/jupyterlab_templates/extension.py
+++ b/jupyterlab_templates/extension.py
@@ -20,8 +20,9 @@ TEMPLATES_IGNORE_FILE = ".jupyterlab_templates_ignore"
 
 
 class TemplatesLoader:
-    def __init__(self, template_dirs, allowed_extensions=None):
+    def __init__(self, template_dirs, allowed_extensions=None, template_label=None):
         self.template_dirs = template_dirs
+        self.template_label = template_label or "Template"
         self.allowed_extensions = allowed_extensions or ["*.ipynb"]
 
     def get_templates(self):
@@ -90,10 +91,14 @@ class TemplatesHandler(JupyterHandler):
     @tornado.web.authenticated
     def get(self):
         temp = self.get_argument("template", "")
-        if temp:
-            self.finish(self.loader.get_templates()[1][temp])
-        else:
-            self.set_status(404)
+        if not temp:
+            return self.set_status(404)
+        template_data = self.loader.get_templates()[1][temp]
+        response = {
+            "template_data": template_data,
+            "template_label": self.loader.template_label
+        }
+        self.finish(response)
 
 
 class TemplateNamesHandler(JupyterHandler):
@@ -102,7 +107,12 @@ class TemplateNamesHandler(JupyterHandler):
 
     @tornado.web.authenticated
     def get(self):
-        self.finish(json.dumps(self.loader.get_templates()[0]))
+        templates, _ = self.loader.get_templates()
+        response = {
+            "templates": templates,
+            "template_label": self.loader.template_label
+        }
+        self.finish(json.dumps(response))
 
 
 def load_jupyter_server_extension(nb_server_app):
@@ -129,7 +139,10 @@ def load_jupyter_server_extension(nb_server_app):
         template_dirs.extend([os.path.join(x, "notebook_templates") for x in jupyter_core.paths.jupyter_path()])
     nb_server_app.log.info("Search paths:\n\t%s" % "\n\t".join(template_dirs))
 
-    loader = TemplatesLoader(template_dirs, allowed_extensions=allowed_extensions)
+    template_label = nb_server_app.config.get("JupyterLabTemplates", {}).get("template_label", "Template")
+    nb_server_app.log.info("Template label: %s" % template_label)
+
+    loader = TemplatesLoader(template_dirs, allowed_extensions=allowed_extensions, template_label=template_label)
     nb_server_app.log.info("Available templates:\n\t%s" % "\n\t".join(t for t in loader.get_templates()[1].keys()))
 
     web_app.add_handlers(


### PR DESCRIPTION
This adds a new configuration setting called `template_label` which can be used to override the text that currently displays the word "Template" on the Jupyter Lab UI. 