### PR TITLE
Add template_label setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ c.JupyterLabTemplates.allowed_extensions = ["*.ipynb"]
 c.JupyterLabTemplates.template_dirs = ['list', 'of', 'template', 'directories']
 c.JupyterLabTemplates.include_default = True
 c.JupyterLabTemplates.include_core_paths = True
+c.JupyterLabTemplates.template_label = "Template"
 ```
 
 ## Templates for libraries
@@ -59,6 +60,7 @@ All notebooks in this directory will be ignored (but has no effect on subdirecto
 - `template_dirs`: a list of absolute directory paths. All files matching `allowed_extensions` in any *subdirectories* of these paths will be listed as templates
 - `include_default`: include the default Sample template (default True)
 - `include_core_paths`: include jupyter core paths (see: jupyter --paths) (default True)
+- `template_label`: set label for template UI icon (default "Template")
 
 
 ## Development

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -77,7 +77,9 @@ function activate(app, menu, browser, launcher) {
   // grab templates from serverextension
   request("get", `${PageConfig.getBaseUrl()}templates/names`).then((res) => {
     if (res.ok) {
-      templates = res.json();
+      const template_data = res.json();
+      templates = template_data.templates;
+      const templateLabel = template_data.template_label || "Template";
 
       if (Object.keys(templates).length > 0) {
         // Add an application command
@@ -90,7 +92,7 @@ function activate(app, menu, browser, launcher) {
               body: new OpenTemplateWidget(),
               buttons: [Dialog.cancelButton(), Dialog.okButton({label: "GO"})],
               focusNodeSelector: "input",
-              title: "Template",
+              title: templateLabel,
             }).then((result) => {
               if (result.button.label === "Cancel") {
                 return;
@@ -137,7 +139,7 @@ function activate(app, menu, browser, launcher) {
           },
           iconClass: "jp-TemplateIcon",
           isEnabled: () => true,
-          label: "Template",
+          label: templateLabel,
         });
 
         // Add a launcher item if the launcher is available.

--- a/jupyterlab_templates/extension.py
+++ b/jupyterlab_templates/extension.py
@@ -91,11 +91,9 @@ class TemplatesHandler(JupyterHandler):
     @tornado.web.authenticated
     def get(self):
         temp = self.get_argument("template", "")
-        if not temp:
-            return self.set_status(404)
-        template_data = self.loader.get_templates()[1][temp]
-        response = {"template_data": template_data, "template_label": self.loader.template_label}
-        self.finish(response)
+        if temp:
+            self.finish(self.loader.get_templates()[1][temp])
+        self.set_status(404)
 
 
 class TemplateNamesHandler(JupyterHandler):


### PR DESCRIPTION
This adds a new configuration setting called `template_label` which can be used to override the text that currently displays the word "Template" on the Jupyter Lab UI. 

Apologies for the previous now closed [PR](https://github.com/finos/jupyterlab_templates/pull/239), I had some troubles with EasyCLA.